### PR TITLE
Bump deps: conduit to 1.1, QuickCheck to 2.7, mtl to 2.2, transformers t...

### DIFF
--- a/leksah.cabal
+++ b/leksah.cabal
@@ -247,16 +247,16 @@ library
     build-depends: Cabal >=1.10.2.0 && <1.22, base >=4.0.0.0 && <4.8, binary >=0.5.0.0 && <0.8,
                        bytestring >=0.9.0.1 && <0.11, containers >=0.2.0.0 && <0.6, directory >=1.0.0.2 && <3.1,
                        filepath >=1.1.0.1 && <1.4, glib >=0.10 && <0.13,
-                       mtl >=1.1.0.2 && <2.2, old-time >=1.0.0.1 && <1.2,
+                       mtl >=1.1.0.2 && <2.3, old-time >=1.0.0.1 && <1.2,
                        parsec >=2.1.0.1 && <3.2, pretty >=1.0.1.0 && <1.2,
                        regex-tdfa >=1.1 && <1.3, regex-base ==0.93.*, utf8-string >=0.3.1.1 && <0.4, array >=0.2.0.0 && <0.6,
                        time >=0.1 && <1.5, ltk >= 0.13.2.0 && <0.14, binary-shared >= 0.8 && <0.9, deepseq >= 1.1.0.0 && <1.4,
                        hslogger >= 1.0.7 && <1.3, leksah-server >=0.13.1.0 && <0.14, network >= 2.2 && <3.0,
-                       ghc >=6.10.1 && <7.9, strict >= 0.3.2 && <0.4, conduit >= 1.0.8 && <1.1, text >= 0.11.1.5 && < 1.2,
-                       gio >=0.12.2 && <0.13, transformers >=0.2.2.0 && <0.4,
+                       ghc >=6.10.1 && <7.9, strict >= 0.3.2 && <0.4, conduit >= 1.1 && <1.2, conduit-extra, text >= 0.11.1.5 && < 1.2,
+                       gio >=0.12.2 && <0.13, transformers >=0.2.2.0 && <0.5,
                        executable-path >=0.0.3 && <0.1,
                        vcsgui >=0.0.4 && < 0.1, vcswrapper >=0.0.4 && < 0.1,
-                       QuickCheck >=2.4.2 && <2.7, haskell-src-exts >=1.13.5 && <1.15,
+                       QuickCheck >=2.4.2 && <2.8, haskell-src-exts >=1.13.5 && <1.16,
                        hlint >=1.8.59 && <1.9, vado >=0.0.1 && <0.1, shakespeare >=2.0.0.1 && <2.1
     exposed-modules: IDE.Leksah IDE.Completion IDE.ImportTool IDE.Find
                      IDE.Sandbox IDE.Session IDE.Command IDE.Keymap IDE.Utils.GUIUtils
@@ -339,7 +339,7 @@ executable bewleksah
 
 test-suite tests
     build-depends: base >=4.0.0.0 && <4.8, Cabal >=1.10.2.0 && <1.22,
-                   QuickCheck >=2.4.2 && <2.7, leksah ==0.13.4.3,
+                   QuickCheck >=2.4.2 && <2.8, leksah ==0.13.4.3,
                    containers, ltk, leksah-server, hslogger,
                    transformers, glib, monad-loops
     if flag(gtk3)
@@ -348,7 +348,7 @@ test-suite tests
     else
         build-depends: gtk >=0.12.4 && <0.13, gtksourceview2 >=0.10.0 && <0.13, webkit -any
     if flag(yi)
-        build-depends: yi >=0.6.6.1 && <0.7
+        build-depends: yi >=0.8.1 && <0.9
     type: exitcode-stdio-1.0
     main-is: Tests.hs
     other-modules: IDE.TextEditor.Tests

--- a/src/IDE/Debug.hs
+++ b/src/IDE/Debug.hs
@@ -82,7 +82,7 @@ import IDE.Utils.Tool (ToolOutput(..), toolProcess, interruptProcessGroupOf)
 import IDE.Workspaces (packageTry)
 import qualified Data.Conduit as C
 import qualified Data.Conduit.List as CL
-import qualified Data.Conduit.Util as CU
+import qualified Data.Conduit.Internal as CU
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.Trans.Reader (ask)
 import Control.Monad.IO.Class (MonadIO(..))

--- a/src/IDE/Package.hs
+++ b/src/IDE/Package.hs
@@ -105,7 +105,7 @@ import IDE.Utils.Tool (executeGhciCommand, getProcessExitCode, interruptProcessG
     ProcessHandle)
 import qualified Data.Conduit as C (Sink)
 import qualified Data.Conduit.List as CL (foldM, fold, consume)
-import qualified Data.Conduit.Util as CU (zipSinks)
+import qualified Data.Conduit.Internal as CU (zipSinks)
 import Data.Conduit (($$))
 import Control.Monad.Trans.Reader (ask)
 import Control.Monad.IO.Class (MonadIO(..))

--- a/src/IDE/Pane/PackageEditor.hs
+++ b/src/IDE/Pane/PackageEditor.hs
@@ -102,7 +102,7 @@ import Distribution.Version (Version(..), orLaterVersion)
 
 import Text.Printf (printf)
 import Control.Applicative ((<*>), (<$>))
-import qualified Data.Conduit.Util as CU (zipSinks)
+import qualified Data.Conduit.Internal as CU (zipSinks)
 import IDE.Utils.Tool (ToolOutput(..))
 import System.Exit (ExitCode(..))
 import qualified Data.Conduit.List as CL (fold)

--- a/src/IDE/Sandbox.hs
+++ b/src/IDE/Sandbox.hs
@@ -28,7 +28,7 @@ import System.Exit (ExitCode(..))
 import System.FilePath (dropFileName)
 import qualified Data.Conduit as C (Sink)
 import qualified Data.Conduit.List as CL (fold)
-import qualified Data.Conduit.Util as CU (zipSinks)
+import qualified Data.Conduit.Internal as CU (zipSinks)
 import IDE.Utils.Tool (ToolOutput(..))
 import IDE.Utils.GUIUtils (__, chooseDir)
 import IDE.Core.State (PackageAction, readIDE, prefs, ipdBuildDir, getMainWindow,


### PR DESCRIPTION
...o 0.4, haskell-src-exts to 0.15. yi dep test version should be consistent.
