### PR TITLE
change leksal style to  "underline = false"

### DIFF
--- a/data/styles/leksah-dark.xml
+++ b/data/styles/leksah-dark.xml
@@ -75,7 +75,7 @@
   <style name="def:error"                   background="red" bold="true"/>
   <style name="def:warning"                 background="yellow"/>
   <style name="def:note"                    foreground="comment" background="yellow" bold="true"/>
-  <style name="def:underlined"              italic="true" underline="true"/>
+  <style name="def:underlined"              italic="true" underline="false"/>
 
   <!-- Language specific styles -->
   <style name="diff:added-line"             foreground="#008B8B"/>

--- a/data/styles/leksah.xml
+++ b/data/styles/leksah.xml
@@ -75,7 +75,7 @@
   <style name="def:error"                   background="red" bold="true"/>
   <style name="def:warning"                 background="yellow"/>
   <style name="def:note"                    foreground="comment" background="yellow" bold="true"/>
-  <style name="def:underlined"              italic="true" underline="true"/>
+  <style name="def:underlined"              italic="true" underline="false"/>
 
   <!-- Language specific styles -->
   <style name="diff:added-line"             foreground="#008B8B"/>


### PR DESCRIPTION
It will fix #66 in "leksal" style.  Now, style "cobalt" and "leksal" won't crash when open files containing special characters. 