### PR TITLE
Some small improvements to the Preferences pane

### DIFF
--- a/src/IDE/Pane/Preferences.hs
+++ b/src/IDE/Pane/Preferences.hs
@@ -85,7 +85,6 @@ import qualified Data.Text as T (isSuffixOf, unpack, pack, null)
 import Data.Monoid ((<>))
 import Control.Applicative ((<$>))
 import Distribution.Text (display, simpleParse)
-import IDE.Pane.Files (refreshFiles)
 
 -- ---------------------------------------------------------------------
 -- This needs to be incremented, when the preferences format changes


### PR DESCRIPTION
* Renamed the "Apply" button to "Preview", I think this is more appropriate w.r.t the "Close" button behaviour
* When the preferences are previewed/saved/restored, they are modified in the IDE state as well. This avoids mixed states, e.g. when previewing a different font size, opening a new document will still use the old size.
* Modifying the preferences in the IDE state is done before the applicators are run, so that they can use the new preferences without explicitly threading the updated value through all the code