### PR TITLE
find and search take current identifier if no selected text

### DIFF
--- a/src/IDE/Command.hs
+++ b/src/IDE/Command.hs
@@ -632,7 +632,7 @@ textPopupMenu ideR menu = do
     mi3 <- menuItemNewWithLabel (__ "Search (metadata)")
     mi3 `on` menuItemActivate $
       reflectIDE_ $ do
-         mbtext <- selectedText
+         mbtext <- selectedTextOrCurrentIdentifier -- if no text selected, search for current identifier
          searchPane <- getSearch Nothing
          case mbtext of
              Just t  -> searchMetaGUI searchPane t

--- a/src/IDE/Find.hs
+++ b/src/IDE/Find.hs
@@ -684,19 +684,19 @@ needFindbar = do
         Nothing -> throwIDE "Find>>needFindbar: Findbar not initialized"
         Just p  -> return p
 
+-- | Find action. If SearchHint==Initial then we'll use the selected text or current identifier to populate the find text box
 editFindInc :: SearchHint -> IDEAction
 editFindInc hint = do
     ideR <- ask
     (fb,_) <- needFindbar
     case hint of
-        Initial -> inActiveBufContext () $ \_ _ ebuf _ _ -> do
-            hasSelection <- hasSelection ebuf
-            when hasSelection $ do
-                (i1,i2)   <- getSelectionBounds ebuf
-                text      <- getText ebuf i1 i2 False
-                findEntry <- liftIO $ getFindEntry fb
-                liftIO $ entrySetText (castToEntry findEntry) text
-                return ()
+        Initial -> do
+               mbtext <- selectedTextOrCurrentIdentifier -- if no text selected, search for current identifier
+               case mbtext of
+                 Just text -> do
+                     findEntry <- liftIO $ getFindEntry fb
+                     liftIO $ entrySetText (castToEntry findEntry) text
+                 Nothing -> return ()
         _ -> return ()
     showFindbar
     reifyIDE $ \ideR   -> do


### PR DESCRIPTION
I realized that right click on text -> search or find didn't work, you had to explicitly select a range of text. But double clicking knows how to selected an identifier, so now if you choose find or search and no text is selected, we'll get the current identifier if any. Two less clicks! Also, I'm trying to add some documentation to the functions I touch, since, ahem, the documentation is a bit lacking in the code.