### PR TITLE
Sync stack.yaml with leksah.cabal changes

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,23 @@
+# Configuration file for building with stack
+# Must be kept in sync with changes to leksah.cabal
+#
+# http://docs.haskellstack.org/en/stable/yaml_configuration/
+
 flags: {}
+
 packages:
 - '.'
+
+# If you have built leksah-server at a local path, you can add it here:
+#- '../leksah-server'
+
 extra-deps:
 - binary-shared-0.8.3
 - ghcjs-codemirror-0.0.0.1
 - ghcjs-dom-0.2.1.0
 - gtk3-mac-integration-0.3.2.0
 - gtksourceview3-0.13.2.0
-- jsaddle-0.2.1.0
+- jsaddle-0.3.0.1
 - regex-tdfa-text-1.0.0.3
 - leksah-server-0.15.0.8
 - ltk-0.15.0.4
@@ -17,5 +27,6 @@ extra-deps:
 - webkitgtk3-0.14.1.0
 - webkitgtk3-javascriptcore-0.13.1.0
 - gtk2hs-buildtools-0.13.0.4
-- gtk3-0.14.1
+- gtk3-0.14.2
+
 resolver: lts-3.1


### PR DESCRIPTION
I know very little Haskell *(which is why I thought I would install an IDE for it)*.  But I wanted to be able to build and modify the IDE.  However, when I tried to use the current version of the haskell platform to build Leksah, it wasn't new enough...for instance complaining that it couldn't find (&) in Base.

So I decided to try out stack.  But the stack file appears to be out of date.  After some amount of guessing I got the leksah-server and leksah to build.  (I'll see if I can put notes up somewhere of the other stuff I had to do.)

Despite not knowing what I'm doing, here I am sending a PR with the changes I needed.  I don't know if there is a better way to get stack to pick up a locally built leksah-server dependency or not.  But in case that is what stack users have to do if they're building the corresponding server I added it in as a comment.

I myself like to put a link to a cheat sheet at the top of any configuration file for quick reference, so I added that too.

Given my limited knowledge on the topic, all I can really say is "this is what made it work for me"!