### PR TITLE
select first executable if none activated

### DIFF
--- a/src/IDE/Package.hs
+++ b/src/IDE/Package.hs
@@ -435,7 +435,7 @@ packageRun' removeGhcjsFlagIfPresent package =
             pd <- liftIO $ liftM flattenPackageDescription
                              (readPackageDescription normal (ipdCabalFile package))
             mbExe <- readIDE activeExe
-            let exe = take 1 . filter (isActiveExe mbExe) $ executables pd
+            let exe = exeToRun mbExe $ executables pd
             let defaultLogName = T.pack . display . pkgName $ ipdPackageId package
                 logName = fromMaybe defaultLogName . listToMaybe $ map (T.pack . exeName) exe
             (logLaunch,logName) <- buildLogLaunchByName logName
@@ -465,8 +465,16 @@ packageRun' removeGhcjsFlagIfPresent package =
                         executeDebugCommand (":main " <> T.unwords (ipdExeFlags package)) (logOutput logLaunch))
                         debug)
             (\(e :: SomeException) -> print e)
-  where
-    isActiveExe selected (Executable name _ _) = selected == Just (T.pack name)
+
+-- | Is the given executable the active one?
+isActiveExe :: Text -> Executable -> Bool
+isActiveExe selected (Executable name _ _) = selected == (T.pack name)
+
+-- | get executable to run
+--   no exe activated, take first one
+exeToRun :: (Maybe Text) -> [Executable] -> [Executable]
+exeToRun Nothing (exe:_) = [exe]
+exeToRun (Just selected) exes = take 1 $ filter (isActiveExe selected) exes
 
 packageRunJavaScript :: PackageAction
 packageRunJavaScript = ask >>= (interruptSaveAndRun . packageRunJavaScript' True)
@@ -499,7 +507,7 @@ packageRunJavaScript' addFlagIfMissing package =
                 pd <- liftIO $ liftM flattenPackageDescription
                                  (readPackageDescription normal (ipdCabalFile package))
                 mbExe <- readIDE activeExe
-                let exe = take 1 . filter (isActiveExe mbExe) $ executables pd
+                let exe = exeToRun mbExe $ executables pd
                 let defaultLogName = T.pack . display . pkgName $ ipdPackageId package
                     logName = fromMaybe defaultLogName . listToMaybe $ map (T.pack . exeName) exe
                 (logLaunch,logName) <- buildLogLaunchByName logName
@@ -521,8 +529,6 @@ packageRunJavaScript' addFlagIfMissing package =
 
                     _ -> return ())
                 (\(e :: SomeException) -> print e)
-  where
-    isActiveExe selected (Executable name _ _) = selected == Just (T.pack name)
 
 packageRegister :: PackageAction
 packageRegister = do

--- a/src/IDE/Package.hs
+++ b/src/IDE/Package.hs
@@ -474,6 +474,7 @@ isActiveExe selected (Executable name _ _) = selected == (T.pack name)
 --   no exe activated, take first one
 exeToRun :: (Maybe Text) -> [Executable] -> [Executable]
 exeToRun Nothing (exe:_) = [exe]
+exeToRun Nothing _ = []
 exeToRun (Just selected) exes = take 1 $ filter (isActiveExe selected) exes
 
 packageRunJavaScript :: PackageAction


### PR DESCRIPTION
I had the case where doing package run fails because it launches stack exec -- without an executable name. I didn't even know about the 'activate executable' menu action. So if activated executable is Nothing we just take the first executable in the package, which in most cases is probably the only one.