### PR TITLE
entrySetPlaceholderText takes a Maybe Text on gtk 3.14 as well

### DIFF
--- a/src/IDE/Find.hs
+++ b/src/IDE/Find.hs
@@ -255,11 +255,7 @@ constructFindReplace = do
     replaceTool <- toolItemNew
     rentry <- entryNew
     widgetSetName rentry "replaceEntry"
-    entrySetPlaceholderText rentry
-#ifdef MIN_VERSION_GTK_3_18
-        $ Just
-#endif
-        "Replace with"
+    entrySetPlaceholderText rentry (Just "Replace with")
     containerAdd replaceTool rentry
     widgetSetName replaceTool "replaceTool"
     toolbarInsert toolbar replaceTool 0
@@ -286,11 +282,7 @@ constructFindReplace = do
     entryTool <- toolItemNew
     entry <- entryNew
     widgetSetName entry "searchEntry"
-    entrySetPlaceholderText entry
-#ifdef MIN_VERSION_GTK_3_18
-        $ Just
-#endif
-        "Find"
+    entrySetPlaceholderText entry (Just "Find")
     containerAdd entryTool entry
     widgetSetName entryTool "searchEntryTool"
     toolItemSetExpand entryTool True


### PR DESCRIPTION
It seems like this function does not need an ifdef for older gtk (@hamishmack I made this a PR because I don't really know when the generated bindings require Maybes and when not, perhaps this breaks another gtk version?).

On gtk 3.14 I got these errors in Find.hs

```
src/IDE/Find.hs:291:9-14:
    No instance for (Data.String.IsString (Maybe Text))
      arising from the literal ‘"Find"’
    In the second argument of ‘entrySetPlaceholderText’, namely
      ‘"Find"’
    In a stmt of a 'do' block: entrySetPlaceholderText entry "Find"
    In the expression:
      do { ideR <- ask;
           toolbar <- toolbarNew;
           toolbarSetStyle toolbar ToolbarStyleIcons;
           toolbarSetIconSize toolbar IconSizeSmallToolbar;
           .... }
``` 