### PR TITLE
Updating build-from-source instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -142,6 +142,7 @@ Install [MSYS2](https://msys2.github.io/) and [Chocolatey](https://chocolatey.or
 
 **Step 2**: Install tools
 
+    cabal update
     cabal install alex happy
     cabal install haskell-gi
 
@@ -155,7 +156,6 @@ Install [MSYS2](https://msys2.github.io/) and [Chocolatey](https://chocolatey.or
 
 **Step 4**: Build Leksah
 
-    cabal update
     cabal new-build exe:leksah-server exe:leksah
 
 **Step 5**: Run leksah


### PR DESCRIPTION
Adding 'cabal update' to the right place in the build-from-source instructions