### PR TITLE
Just look if the Shift modifier is in the mods list

### DIFF
--- a/src/IDE/Find.hs
+++ b/src/IDE/Find.hs
@@ -358,7 +358,7 @@ constructFindReplace = do
         mbName <- getEventKeyKeyval e >>= keyvalName
         mods <- getEventKeyState e
         case mbName of
-            Just "Return" | [ModifierTypeShiftMask] ==  mods ->
+            Just "Return" | ModifierTypeShiftMask `elem`  mods ->
                                 doSearch toolbar Backward ideR >> return True
             Just "Down"   -> doSearch toolbar Forward ideR >> return True
             Just "Up"     -> doSearch toolbar Backward ideR >> return True


### PR DESCRIPTION
Fixes #337

Doesn't look anymore if the mods list only consists of the Shift
modifier, but if it just contains it.