### PR TITLE
"File has changed" dialog closes with escape/cancel button

### DIFF
--- a/src/IDE/Pane/SourceBuffer.hs
+++ b/src/IDE/Pane/SourceBuffer.hs
@@ -877,15 +877,19 @@ checkModTime buf = do
                                                         revert buf
                                                         modifyIDE_ $ \ide -> ide{prefs = (prefs ide) {autoLoad = True}}
                                                         return (False, True)
-                                                    AnotherResponseType 3 -> do
-                                                        nmt2 <- liftIO $ getModificationTime fn
-                                                        liftIO $ writeIORef (modTime buf) (Just nmt2)
-                                                        return (True, True)
+                                                    AnotherResponseType 3 -> dontLoad fn
+                                                    ResponseTypeDeleteEvent -> dontLoad fn
                                                     _              -> return (False, False)
+
                                     else return (False, False)
                         else return (False, False)
                 Nothing -> return (False, False)
 
+    where
+        dontLoad fn = do
+            nmt2 <- liftIO $ getModificationTime fn
+            liftIO $ writeIORef (modTime buf) (Just nmt2)
+            return (True, True)
 setModTime :: IDEBuffer -> IDEAction
 setModTime buf = do
     let name = paneName buf


### PR DESCRIPTION
Fixes #358

Add the ResponseTypeDeleteEvent and tell it to just don't load the new
file if you cancel the dialog.