### PR TITLE
Replace some deprecated functions

### DIFF
--- a/src/IDE/BufferMode.hs
+++ b/src/IDE/BufferMode.hs
@@ -48,7 +48,7 @@ import qualified Data.Text as T
 import GI.Gtk.Objects.ScrolledWindow (ScrolledWindow(..))
 import GI.Gtk.Objects.Widget (toWidget)
 import GI.Gtk.Objects.Notebook (notebookPageNum, Notebook(..))
-import GI.Gtk (VBox)
+import GI.Gtk (Box)
 
 -- * Buffer Basics
 
@@ -60,7 +60,7 @@ data IDEBuffer = forall editor. TextEditor editor => IDEBuffer {
 ,   bufferName      ::  Text
 ,   addedIndex      ::  Int
 ,   sourceView      ::  EditorView editor
-,   vBox  ::  VBox
+,   vBox            ::  Box
 ,   modTime         ::  IORef (Maybe UTCTime)
 ,   mode            ::  Mode
 } deriving (Typeable)

--- a/src/IDE/Command.hs
+++ b/src/IDE/Command.hs
@@ -143,7 +143,7 @@ import GI.Gtk.Structs.IconSet (iconSetNewFromPixbuf)
 import GI.Gtk.Objects.IconTheme (iconThemeAddBuiltinIcon)
 import GI.Gtk.Objects.Window
        (IsWindow, windowAddAccelGroup, windowSetIconFromFile, Window(..))
-import GI.Gtk.Objects.VBox (vBoxNew)
+import GI.Gtk.Objects.Box (boxNew)
 import Graphics.UI.Editor.Parameters
        (boxPackEnd', Packing(..), boxPackStart')
 import GI.Gdk.Structs.EventKey
@@ -151,6 +151,7 @@ import GI.Gdk.Structs.EventKey
 import GI.Gdk.Functions (keyvalToUnicode, keyvalName)
 import GI.Gdk.Flags (ModifierType, ModifierType(..))
 import GI.Gtk.Objects.AccelGroup (AccelGroup(..))
+import GI.Gtk.Enums (Orientation(..))
 import Data.GI.Base.BasicTypes (NullToNothing(..))
 
 import IDE.LPaste
@@ -802,7 +803,7 @@ instrumentWindow win prefs topWidget = do
     iconExists  <- liftIO $ doesFileExist iconPath
     when iconExists $
         windowSetIconFromFile win iconPath
-    vb <- vBoxNew False 1  -- Top-level vbox
+    vb <- boxNew OrientationVertical 1  -- Top-level vbox
     widgetSetName vb "topBox"
     (acc,menu,toolbar) <- getMenuAndToolbars uiManager'
     boxPackStart' vb menu PackNatural 0

--- a/src/IDE/Completion.hs
+++ b/src/IDE/Completion.hs
@@ -44,7 +44,7 @@ import Data.GI.Base
 import GI.Gdk.Enums (GrabStatus(..), WindowTypeHint(..))
 import GI.Gtk.Objects.Container
        (containerRemove, containerAdd, containerSetBorderWidth)
-import GI.Gtk.Objects.HPaned (hPanedNew)
+import GI.Gtk.Objects.Paned (panedNew)
 import GI.Gtk.Objects.ScrolledWindow (scrolledWindowNew)
 import GI.Gtk.Objects.Adjustment (noAdjustment)
 import GI.Gtk.Objects.Widget
@@ -66,7 +66,7 @@ import GI.Pango.Structs.FontDescription
 import GI.Gtk.Objects.TreeViewColumn
        (noTreeViewColumn, treeViewColumnPackStart, setTreeViewColumnMinWidth,
         setTreeViewColumnSizing, treeViewColumnNew)
-import GI.Gtk.Enums (TreeViewColumnSizing(..), WindowType(..))
+import GI.Gtk.Enums (TreeViewColumnSizing(..), WindowType(..), Orientation(..))
 import GI.Gtk.Objects.CellRendererText
        (setCellRendererTextText, cellRendererTextNew)
 import Data.GI.Gtk.ModelView.CellLayout
@@ -175,7 +175,7 @@ initCompletion sourceView always = do
             setWindowDefaultHeight window $ fromIntegral height
             setWindowTransientFor  window $ head windows
             containerSetBorderWidth window 3
-            paned      <- hPanedNew
+            paned      <- panedNew OrientationHorizontal
             containerAdd window paned
             nameScrolledWindow <- scrolledWindowNew noAdjustment noAdjustment
             widgetSetSizeRequest nameScrolledWindow 250 40

--- a/src/IDE/Pane/Errors.hs
+++ b/src/IDE/Pane/Errors.hs
@@ -53,7 +53,7 @@ import Data.Tree (Forest, Tree(..), Tree)
 import Data.Function.Compat ((&))
 import System.Log.Logger (debugM)
 import Data.Foldable (forM_)
-import GI.Gtk.Objects.VBox (vBoxNew, VBox(..))
+import GI.Gtk.Objects.Box (boxNew, Box(..))
 import GI.Gtk.Objects.ScrolledWindow
        (scrolledWindowSetPolicy, scrolledWindowSetShadowType,
         scrolledWindowNew, ScrolledWindow(..))
@@ -71,7 +71,6 @@ import GI.Gtk.Objects.Widget
 import Data.GI.Base (set, get)
 import GI.Gtk.Objects.Notebook (Notebook(..))
 import GI.Gtk.Objects.Window (Window(..))
-import GI.Gtk.Objects.HBox (hBoxNew)
 import Graphics.UI.Editor.Parameters (Packing(..), boxPackStart')
 import GI.Gtk.Objects.TreeViewColumn
        (noTreeViewColumn, TreeViewColumn(..), treeViewColumnSetSizing,
@@ -83,7 +82,7 @@ import Data.GI.Gtk.ModelView.CellLayout
        (cellLayoutSetDataFunc', cellLayoutSetDataFunction)
 import GI.Gtk.Enums
        (PolicyType(..), ShadowType(..), SelectionMode(..),
-        TreeViewColumnSizing(..))
+        TreeViewColumnSizing(..), Orientation(..))
 import GI.Gtk.Objects.CellRendererText
        (setCellRendererTextText, cellRendererTextNew)
 import GI.Gtk.Interfaces.TreeModel
@@ -112,7 +111,7 @@ import GI.Gtk (getToggleButtonActive)
 
 -- | The representation of the Errors pane
 data ErrorsPane      =   ErrorsPane {
-    vbox              :: VBox
+    vbox              :: Box
 ,   scrolledView      :: ScrolledWindow
 ,   treeView          :: TreeView
 ,   errorStore        :: ForestStore ErrorRecord
@@ -180,10 +179,10 @@ builder' _pp _nb _windows = do
     ideR <- ask
     errorStore   <- forestStoreNew []
 
-    vbox         <- vBoxNew False 0
+    vbox         <- boxNew OrientationVertical 0
 
     -- Top box with buttons
-    hbox <- hBoxNew False 0
+    hbox <- boxNew OrientationHorizontal 0
     boxPackStart' vbox hbox PackNatural 0
 
 

--- a/src/IDE/Pane/Log.hs
+++ b/src/IDE/Pane/Log.hs
@@ -68,13 +68,12 @@ import Data.Monoid (Monoid(..), (<>))
 import Data.List (elemIndex, isPrefixOf, isSuffixOf, findIndex)
 import qualified Data.Foldable as F (toList, forM_)
 import qualified Data.Sequence as Seq (empty)
-import GI.Gtk.Objects.VBox (vBoxNew, VBox(..))
+import GI.Gtk.Objects.Box (boxNew, Box(..))
 import GI.Gtk.Objects.TextView
        (textViewScrollToMark, textViewGetBuffer,
         textViewScrollMarkOnscreen, textViewGetLineAtY,
         textViewWindowToBufferCoords, onTextViewPopulatePopup,
         textViewSetBuffer, textViewSetEditable, textViewNew, TextView(..))
-import GI.Gtk.Objects.HBox (hBoxNew, HBox(..))
 import GI.Gtk.Objects.ComboBox
        (onComboBoxChanged, comboBoxSetActive, comboBoxGetActive,
         ComboBox(..))
@@ -113,7 +112,7 @@ import GI.Gtk.Objects.Adjustment (noAdjustment)
 import GI.Gtk.Objects.Container
        (containerGetChildren, containerAdd)
 import GI.Gtk.Enums
-       (TextWindowType(..), ShadowType(..), PolicyType(..))
+       (TextWindowType(..), ShadowType(..), PolicyType(..), Orientation(..))
 import Control.Monad.Trans.Class (MonadTrans(..))
 import GI.Gdk.Structs.EventButton
        (getEventButtonY, getEventButtonX, getEventButtonButton,
@@ -142,9 +141,9 @@ import Control.Monad.IO.Class (MonadIO)
 
 
 data IDELog = IDELog {
-    logMainContainer :: VBox
+    logMainContainer :: Box
 ,   logLaunchTextView :: TextView
-,   logButtons :: HBox
+,   logButtons :: Box
 ,   logLaunchBox :: ComboBox
 } deriving Typeable
 
@@ -344,10 +343,10 @@ builder' pp nb windows = do
     modifyIDE_ $ \ide -> ide { logLaunches = map}
 
     ideR <- ask
-    mainContainer <- vBoxNew False 0
+    mainContainer <- boxNew OrientationVertical 0
 
     -- top, buttons and combobox
-    hBox <- hBoxNew False 0
+    hBox <- boxNew OrientationHorizontal 0
     boxPackStart' mainContainer hBox PackNatural 0
 
     terminateBtn <- buttonNewWithLabel (__ "Terminate process")

--- a/src/IDE/Pane/Modules.hs
+++ b/src/IDE/Pane/Modules.hs
@@ -85,8 +85,7 @@ import Data.Monoid ((<>))
 import qualified Text.Printf as S (printf)
 import Text.Printf (PrintfType)
 import qualified Data.Text.IO as T (writeFile)
-import GI.Gtk.Objects.VBox (vBoxNew, VBox(..))
-import GI.Gtk.Objects.HPaned (hPanedNew, HPaned(..))
+import GI.Gtk.Objects.Paned (panedNew, Paned(..))
 import Data.GI.Gtk.ModelView.ForestStore
        (forestStoreInsertTree, forestStoreGetTree, forestStoreGetValue,
         ForestStore(..))
@@ -115,7 +114,8 @@ import GI.Gtk.Objects.TreeViewColumn
 import GI.Gtk.Enums
        (ButtonsType(..), MessageType(..), WindowPosition(..),
         ResponseType(..), ButtonBoxStyle(..), PolicyType(..),
-        ShadowType(..), SortType(..), TreeViewColumnSizing(..))
+        ShadowType(..), SortType(..), TreeViewColumnSizing(..),
+        Orientation(..))
 import GI.Gtk.Interfaces.CellLayout (cellLayoutPackStart)
 import Data.GI.Gtk.ModelView.CellLayout
        (cellLayoutSetDataFunction)
@@ -136,9 +136,8 @@ import GI.Gtk.Objects.Adjustment (noAdjustment)
 import GI.Gtk.Objects.Container (containerAdd)
 import Graphics.UI.Frame.Rectangle
        (getRectangleY, getRectangleX, Rectangle(..))
-import GI.Gtk.Objects.HButtonBox (hButtonBoxNew)
-import GI.Gtk.Objects.Box (boxReorderChild, Box(..), boxSetSpacing)
-import GI.Gtk.Objects.ButtonBox (buttonBoxSetLayout)
+import GI.Gtk.Objects.Box (boxReorderChild, Box(..), boxSetSpacing, boxNew)
+import GI.Gtk.Objects.ButtonBox (buttonBoxSetLayout, buttonBoxNew)
 import GI.Gtk.Objects.ToggleButton
        (toggleButtonGetActive, onToggleButtonToggled,
         toggleButtonSetActive)
@@ -186,8 +185,8 @@ printf = S.printf . T.unpack
 type ModuleRecord = (Text, Maybe (ModuleDescr,PackageDescr))
 
 data IDEModules     =   IDEModules {
-    outer            ::   VBox
-,   paned            ::   HPaned
+    outer            ::   Box
+,   paned            ::   Paned
 ,   treeView         ::   TreeView
 ,   forestStore      ::   ForestStore ModuleRecord
 ,   descrView        ::   TreeView
@@ -380,7 +379,7 @@ instance RecoverablePane IDEModules ModulesState IDEM where
         treeViewSetEnableSearch descrView True
         treeViewSetSearchEqualFunc descrView
             (\_ _ key iter -> descrViewSearch descrView descrStore key iter)
-        pane'           <-  hPanedNew
+        pane'           <-  panedNew OrientationHorizontal
         sw              <-  scrolledWindowNew noAdjustment noAdjustment
         scrolledWindowSetShadowType sw ShadowTypeIn
         containerAdd sw treeView
@@ -395,7 +394,7 @@ instance RecoverablePane IDEModules ModulesState IDEM where
         x <- getRectangleX rect
         y <- getRectangleY rect
         panedSetPosition pane' (max 200 (x `quot` 2))
-        box             <-  hButtonBoxNew
+        box             <-  buttonBoxNew OrientationHorizontal
         boxSetSpacing box 2
         buttonBoxSetLayout box ButtonBoxStyleSpread
         rb1             <-  radioButtonNewWithLabel ([]::[RadioButton]) (__ "Package")
@@ -412,7 +411,7 @@ instance RecoverablePane IDEModules ModulesState IDEM where
         boxPackEnd' box cb2 PackNatural 0
 
 
-        boxOuter        <-  vBoxNew False 0
+        boxOuter        <-  boxNew OrientationVertical 0
         boxPackStart' boxOuter box PackNatural 2
         boxPackStart' boxOuter pane' PackGrow 0
         oldState <- liftIO $ newIORef $ SelectionState Nothing Nothing SystemScope False

--- a/src/IDE/Pane/PackageEditor.hs
+++ b/src/IDE/Pane/PackageEditor.hs
@@ -110,21 +110,21 @@ import GI.Gtk.Objects.Window
 import GI.Gtk.Objects.FileChooserDialog (FileChooserDialog(..))
 import GI.Gtk.Enums
        (ShadowType(..), WindowPosition(..), ButtonsType(..),
-        MessageType(..), ResponseType(..), FileChooserAction(..))
+        MessageType(..), ResponseType(..), FileChooserAction(..),
+        Orientation(..))
 import GI.Gtk.Objects.Dialog
        (Dialog(..), constructDialogUseHeaderBar, dialogGetActionArea, dialogGetContentArea)
 import Data.GI.Base (on, unsafeCastTo, set, new')
-import GI.Gtk.Objects.Box (boxPackEnd, Box(..))
+import GI.Gtk.Objects.Box (boxNew, boxPackEnd, Box(..))
 import GI.Gtk.Objects.Widget
        (widgetSetSensitive, toWidget, widgetDestroy, widgetShowAll,
         widgetGrabDefault, setWidgetCanDefault)
 import GI.Gtk.Objects.MessageDialog
        (setMessageDialogText, constructMessageDialogButtons, setMessageDialogMessageType,
         MessageDialog(..))
-import GI.Gtk.Objects.VBox (vBoxNew, VBox(..))
 import GI.Gtk.Objects.Notebook (Notebook(..))
-import GI.Gtk.Objects.HButtonBox (hButtonBoxNew)
-import GI.Gtk.Objects.Button (onButtonClicked, buttonNewFromStock)
+import GI.Gtk.Objects.ButtonBox (buttonBoxNew)
+import GI.Gtk.Objects.Button (onButtonClicked, buttonNewWithLabel)
 import GI.Gtk.Objects.Label (labelSetMarkup, labelNew)
 import GI.Gtk.Objects.CellRendererText (setCellRendererTextText)
 
@@ -599,7 +599,7 @@ toEditor pd =
 --
 
 data PackagePane             =   PackagePane {
-    packageBox              ::   VBox,
+    packageBox              ::   Box,
     packageNotifer          ::   Notifier
 } deriving Typeable
 
@@ -678,13 +678,13 @@ builder' :: FilePath ->
     IDEM (Maybe PackagePane,Connections)
 builder' packageDir packageD packageDescr afterSaveAction initialPackagePath modules packageInfos fields
     origPackageD panePath nb window  = reifyIDE $ \ ideR -> do
-    vb      <-  vBoxNew False 0
-    bb      <-  hButtonBoxNew
-    save    <- buttonNewFromStock "gtk-save"
+    vb      <-  boxNew OrientationVertical 0
+    bb      <-  buttonBoxNew OrientationHorizontal
+    save    <- buttonNewWithLabel "gtk-save"
     widgetSetSensitive save False
-    closeB  <- buttonNewFromStock "gtk-close"
-    addB    <- buttonNewFromStock (__ "Add Build Info")
-    removeB <- buttonNewFromStock (__ "Remove Build Info")
+    closeB  <- buttonNewWithLabel "gtk-close"
+    addB    <- buttonNewWithLabel (__ "Add Build Info")
+    removeB <- buttonNewWithLabel (__ "Remove Build Info")
     label   <-  labelNew (Nothing :: Maybe Text)
     boxPackStart' bb addB PackNatural 0
     boxPackStart' bb removeB PackNatural 0

--- a/src/IDE/Pane/PackageFlags.hs
+++ b/src/IDE/Pane/PackageFlags.hs
@@ -51,23 +51,22 @@ import Data.Text (Text)
 import Data.Monoid ((<>))
 import qualified Data.Text as T (unwords, unpack, pack)
 import Control.Applicative ((<$>))
-import GI.Gtk.Objects.VBox (vBoxNew, VBox(..))
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.GI.Base.ManagedPtr (unsafeCastTo)
 import GI.Gtk.Objects.Widget (widgetSetSensitive, Widget(..))
-import GI.Gtk.Objects.HButtonBox (hButtonBoxNew)
-import GI.Gtk.Objects.Box (boxSetSpacing)
-import GI.Gtk.Objects.ButtonBox (buttonBoxSetLayout)
+import GI.Gtk.Objects.Box (boxSetSpacing, Box(..), boxNew)
+import GI.Gtk.Objects.ButtonBox (buttonBoxSetLayout, buttonBoxNew)
 import GI.Gtk.Enums
-       (PolicyType(..), ShadowType(..), ButtonBoxStyle(..))
-import GI.Gtk.Objects.Button (onButtonClicked, buttonNewFromStock)
+       (PolicyType(..), ShadowType(..), ButtonBoxStyle(..),
+        Orientation(..))
+import GI.Gtk.Objects.Button (onButtonClicked, buttonNewWithLabel)
 import GI.Gtk.Objects.Adjustment (noAdjustment)
 import GI.Gtk.Objects.ScrolledWindow
        (scrolledWindowSetPolicy, scrolledWindowAddWithViewport,
         scrolledWindowSetShadowType, scrolledWindowNew)
 
 data IDEFlags               =   IDEFlags {
-    flagsBox                ::   VBox
+    flagsBox                ::   Box
 } deriving Typeable
 
 data FlagsState             =   FlagsState
@@ -108,14 +107,14 @@ instance RecoverablePane IDEFlags FlagsState IDEM where
 
 -- | Builds the Flags pane
 builder' idePackage flagsDesc flatflagsDesc pp nb window ideR = do
-    vb                  <-  vBoxNew False 0
+    vb                  <-  boxNew OrientationVertical 0
     let flagsPane = IDEFlags vb
-    bb                  <-  hButtonBoxNew
+    bb                  <-  buttonBoxNew OrientationHorizontal
     boxSetSpacing bb 6
     buttonBoxSetLayout bb ButtonBoxStyleSpread
-    saveB               <-  buttonNewFromStock "gtk-save"
+    saveB               <-  buttonNewWithLabel "gtk-save"
     widgetSetSensitive saveB False
-    cancelB             <-  buttonNewFromStock "gtk-cancel"
+    cancelB             <-  buttonNewWithLabel "gtk-cancel"
     boxPackStart' bb cancelB PackNatural 0
     boxPackStart' bb saveB PackNatural 0
     (widget,injb,ext,notifier)

--- a/src/IDE/Pane/Search.hs
+++ b/src/IDE/Pane/Search.hs
@@ -51,7 +51,6 @@ import GI.Gtk.Objects.ScrolledWindow
 import Data.GI.Gtk.ModelView.SeqStore
        (seqStoreGetValue, seqStoreAppend, seqStoreClear, seqStoreNew,
         SeqStore(..))
-import GI.Gtk.Objects.VBox (vBoxNew, VBox(..))
 import GI.Gtk.Objects.Entry
        (entrySetText, entryNew, entryGetText, Entry(..))
 import GI.Gtk.Objects.TreeView
@@ -62,14 +61,13 @@ import Data.GI.Base.ManagedPtr (unsafeCastTo)
 import GI.Gtk.Objects.Widget
        (toWidget, setWidgetSensitive, onWidgetKeyReleaseEvent,
         afterWidgetFocusInEvent, Widget(..))
-import GI.Gtk.Objects.HBox (hBoxNew)
 import GI.Gtk.Objects.RadioButton
        (RadioButton(..), radioButtonNewWithLabelFromWidget,
         radioButtonNewWithLabel)
 import GI.Gtk.Objects.ToggleButton
        (toggleButtonGetActive, toggleButtonSetActive)
 import GI.Gtk.Objects.CheckButton (checkButtonNewWithLabel)
-import GI.Gtk.Objects.Box (boxPackEnd, boxPackStart)
+import GI.Gtk.Objects.Box (boxPackEnd, boxPackStart, Box(..), boxNew)
 import Graphics.UI.Editor.Parameters
        (boxPackEnd', boxPackStart', Packing(..))
 import GI.Gtk.Objects.CellRendererText (cellRendererTextNew)
@@ -84,7 +82,7 @@ import GI.Gtk.Objects.TreeSelection
        (treeSelectionSetMode)
 import GI.Gtk.Enums
        (PolicyType(..), ShadowType(..), SelectionMode(..),
-        TreeViewColumnSizing(..))
+        TreeViewColumnSizing(..), Orientation(..))
 import GI.Gtk.Objects.Adjustment (noAdjustment)
 import GI.Gtk.Objects.Container (containerAdd)
 import GI.Gtk.Objects.ToggleButton (onToggleButtonToggled)
@@ -107,7 +105,7 @@ data IDESearch      =   IDESearch {
 ,   searchStore     ::   SeqStore Descr
 ,   searchScopeRef  ::   IORef Scope
 ,   searchModeRef   ::   IORef SearchMode
-,   topBox          ::   VBox
+,   topBox          ::   Box
 ,   entry           ::   Entry
 ,   scopeSelection  ::   Scope -> IDEAction
 ,   modeSelection   ::   SearchMode -> IDEAction
@@ -150,7 +148,7 @@ buildSearchPane =
         mode    = Prefix False
     in reifyIDE $ \ ideR -> do
 
-        scopebox        <-  hBoxNew True 2
+        scopebox        <-  boxNew OrientationHorizontal 2
         rb1             <-  radioButtonNewWithLabel ([]::[RadioButton]) (__ "Package")
         rb2             <-  radioButtonNewWithLabelFromWidget (Just rb1) (__ "Workspace")
         rb3             <-  radioButtonNewWithLabelFromWidget (Just rb1) (__ "System")
@@ -162,7 +160,7 @@ buildSearchPane =
         boxPackStart' scopebox rb3 PackGrow 2
         boxPackEnd' scopebox cb2 PackNatural 2
 
-        modebox         <-  hBoxNew True 2
+        modebox         <-  boxNew OrientationHorizontal 2
         mb1             <-  radioButtonNewWithLabel ([]::[RadioButton]) (__ "Exact")
         mb2             <-  radioButtonNewWithLabelFromWidget (Just mb1) (__ "Prefix")
         mb3             <-  radioButtonNewWithLabelFromWidget (Just mb1) (__ "Regex")
@@ -262,7 +260,7 @@ buildSearchPane =
 
         entry   <-  entryNew
 
-        box             <-  vBoxNew False 2
+        box             <-  boxNew OrientationVertical 2
         boxPackStart' box scopebox PackNatural 0
         boxPackStart' box sw PackGrow 0
         boxPackStart' box modebox PackNatural 0

--- a/src/IDE/Pane/SourceBuffer.hs
+++ b/src/IDE/Pane/SourceBuffer.hs
@@ -148,7 +148,8 @@ import GI.Gtk.Objects.ScrolledWindow
        (setScrolledWindowShadowType, scrolledWindowSetPolicy)
 import GI.Gtk.Enums
        (FileChooserAction(..), WindowPosition(..), ResponseType(..),
-        ButtonsType(..), MessageType(..), ShadowType(..), PolicyType(..))
+        ButtonsType(..), MessageType(..), ShadowType(..), PolicyType(..),
+        Orientation(..))
 import GI.Gdk.Structs.EventKey
        (getEventKeyState, getEventKeyKeyval)
 import GI.Gdk.Functions (keyvalName)
@@ -177,7 +178,7 @@ import GI.Gdk.Structs.Atom (atomIntern)
 import GI.Gdk.Structs.EventButton (getEventButtonType)
 import GI.Gdk.Enums (EventType(..))
 import GI.Gtk
-       (boxPackStart, vBoxNew, Container(..),
+       (boxPackStart, boxNew, Container(..),
         containerAdd, infoBarGetContentArea,
         labelNew, infoBarNew)
 import Data.GI.Base.ManagedPtr (unsafeCastTo)
@@ -627,7 +628,7 @@ builder' useCandy mbfn ind bn rbn ct prefs fileContents modTime pp nb windows =
         liftIO $ debugM "lekash" "makeBuffer setScrolledWindowShadowType done"
 
 
-        box <- vBoxNew False 0
+        box <- boxNew OrientationVertical 0
         when (not isEditable) $ liftIO $ do
             bar <- infoBarNew
             lab <- labelNew (Just "This file is opened in read-only mode because it comes from a non-local package")

--- a/src/IDE/Pane/WebKit/Output.hs
+++ b/src/IDE/Pane/WebKit/Output.hs
@@ -46,7 +46,7 @@ import Control.Applicative ((<$>))
 import System.Log.Logger (debugM)
 import Data.Text (Text)
 import qualified Data.Text as T (unpack, pack)
-import GI.Gtk.Objects.VBox (vBoxNew, VBox(..))
+import GI.Gtk.Objects.Box (boxNew, Box(..))
 import GI.Gtk.Objects.Entry
        (entryGetText, onEntryActivate, entrySetText, entryNew, Entry(..))
 import GI.WebKit.Objects.WebView
@@ -61,7 +61,7 @@ import GI.Gtk.Objects.ScrolledWindow
        (scrolledWindowSetPolicy, scrolledWindowSetShadowType,
         scrolledWindowNew)
 import GI.Gtk.Objects.Adjustment (noAdjustment)
-import GI.Gtk.Enums (PolicyType(..), ShadowType(..))
+import GI.Gtk.Enums (PolicyType(..), ShadowType(..), Orientation(..))
 import Graphics.UI.Editor.Parameters (Packing(..), boxPackStart')
 import GI.Gtk.Objects.Container (containerAdd)
 import GI.Gdk (getEventKeyState, getEventKeyKeyval, keyvalName)
@@ -81,7 +81,7 @@ import Data.GI.Base.ManagedPtr (unsafeCastTo)
 import Data.GI.Base.BasicTypes (NullToNothing(..))
 
 data IDEOutput = IDEOutput {
-    vbox          :: VBox
+    vbox          :: Box
   , uriEntry      :: Entry
   , webView       :: WebView
   , alwaysHtmlRef :: IORef Bool
@@ -115,7 +115,7 @@ instance RecoverablePane IDEOutput OutputState IDEM where
                 liftIO $ writeIORef (alwaysHtmlRef p) alwaysHtml
         return mbPane
     builder pp nb windows = reifyIDE $ \ ideR -> do
-        vbox <- vBoxNew False 0
+        vbox <- boxNew OrientationVertical 0
         uriEntry <- entryNew
         entrySetText uriEntry "http://"
         scrolledView <- scrolledWindowNew noAdjustment noAdjustment

--- a/src/IDE/Statusbar.hs
+++ b/src/IDE/Statusbar.hs
@@ -30,10 +30,10 @@ import GI.Gtk.Objects.Statusbar
        (Statusbar(..), statusbarNew, statusbarPush, statusbarPop)
 import GI.Gtk.Objects.Window (setWindowTitle)
 import GI.Gtk.Objects.Image
-       (Image(..), imageSetPixelSize, imageNewFromStock,
-        imageSetFromStock)
-import GI.Gtk.Enums (IconSize(..))
-import GI.Gtk.Objects.HBox (hBoxNew, HBox(..))
+       (Image(..), imageSetPixelSize, imageNewFromIconName,
+        imageSetFromIconName)
+import GI.Gtk.Enums (IconSize(..), Orientation(..))
+import GI.Gtk.Objects.Box (boxNew, Box(..))
 import GI.Gtk.Objects.Widget (widgetSetSizeRequest, widgetSetName)
 import Graphics.UI.Editor.Parameters
        (Packing(..), boxPackEnd', boxPackStart')
@@ -82,15 +82,15 @@ changeStatusbar = postAsyncIDE . mapM_ changeStatusbar'
         return ()
     changeStatusbar' (CompartmentBuild bool) =  do
         im <- getImBuild
-        imageSetFromStock im (if bool then "ide_build" else "ide_empty") (fromIntegral . fromEnum $ IconSizeMenu)
+        imageSetFromIconName im (if bool then "ide_build" else "ide_empty") (fromIntegral . fromEnum $ IconSizeMenu)
         return ()
     changeStatusbar' (CompartmentCollect bool) =  do
         im <- getImCollect
-        imageSetFromStock im (if bool then "ide_rebuild_meta" else "ide_empty") (fromIntegral . fromEnum $ IconSizeMenu)
+        imageSetFromIconName im (if bool then "ide_rebuild_meta" else "ide_empty") (fromIntegral . fromEnum $ IconSizeMenu)
         return ()
 
 
-buildStatusbar :: MonadIO m => m HBox
+buildStatusbar :: MonadIO m => m Box
 buildStatusbar = do
     sblk <- statusbarNew
     widgetSetName sblk "statusBarSpecialKeys"
@@ -116,15 +116,15 @@ buildStatusbar = do
     widgetSetName sbio "statusBarInsertOverwrite"
     widgetSetSizeRequest sbio 60 (-1)
 
-    buildImage <- imageNewFromStock "ide_empty" (fromIntegral $ fromEnum IconSizeMenu)
+    buildImage <- imageNewFromIconName "ide_empty" (fromIntegral $ fromEnum IconSizeMenu)
     widgetSetName buildImage "buildImage"
     imageSetPixelSize buildImage 16
 
-    collectImage <- imageNewFromStock "ide_empty" (fromIntegral $ fromEnum IconSizeMenu)
+    collectImage <- imageNewFromIconName "ide_empty" (fromIntegral $ fromEnum IconSizeMenu)
     widgetSetName collectImage "collectImage"
     imageSetPixelSize collectImage 16
 
-    hb <- hBoxNew False 1
+    hb <- boxNew OrientationHorizontal 1
     widgetSetName hb "statusBox"
     boxPackStart' hb sblk PackGrow 0
     boxPackStart' hb sbap PackGrow 0


### PR DESCRIPTION
Partly covers #367.

For some deprecated functions GTK doesn't provide an alternative (or it is also deprecated), others require a deeper understanding of the code to be replaced.