### PR TITLE
Fix brackets in PATH oneliner

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,16 +85,17 @@ cd leksah
 cabal update
 cabal install alex happy
 cabal install haskell-gi
-echo 'PATH: '"$PATH"
+echo 'Shell is '"$SHELL"
+echo 'With PATH='"$SHELL"' -c '"echo $PATH"
 ```
-Make sure `~/.cabal/bin` is present in PATH of `echo "$SHELL"` (*Windows:* Make sure `%APPDATA%\cabal\bin` is present in PATH).
+Make sure `~/.cabal/bin` is present in PATH of your shell (*Windows:* Make sure `%APPDATA%\cabal\bin` is present in PATH).
 
 To add cabal path to BASH:
 ```shell
-sed -i 's;^PATH=.*;PATH='"$PATH"':'"$HOME"'/.cabal/bin;' ~/.bashrc
+sed -i 's;^PATH=.*;PATH='"$SHELL"' -c '"echo $PATH"':'"$HOME"'/.cabal/bin;' ~/.bashrc
 ```
 
-If ZSH is your `$SHELL` - instead change file ~/.zshrc.
+If ZSH is your `$SHELL` - change file `~/.zshrc` instead.
 
 ##### Step 3.a.2: Build and run Leksah
 ###### OS X using MacPorts

--- a/Readme.md
+++ b/Readme.md
@@ -87,8 +87,15 @@ cabal install alex happy
 cabal install haskell-gi
 echo 'PATH: '"$PATH"
 ```
-Make sure `~/.cabal/bin` is present in PATH (*Windows:* Make sure `%APPDATA%\cabal\bin` is present in PATH).
-   
+Make sure `~/.cabal/bin` is present in PATH of `echo "$SHELL"` (*Windows:* Make sure `%APPDATA%\cabal\bin` is present in PATH).
+
+To add cabal path to BASH:
+```shell
+sed -i 's;^PATH=.*;PATH='"$PATH"':'"$HOME"'/.cabal/bin;' ~/.bashrc
+```
+
+If ZSH is your `$SHELL` - instead change file ~/.zshrc.
+
 ##### Step 3.a.2: Build and run Leksah
 ###### OS X using MacPorts
 ```shell
@@ -107,7 +114,7 @@ stack install alex happy
 stack install haskell-gi
 stack install gtk2hs-buildtools
 ```
-##### Step 3.a.2: Build and run Leksah
+##### Step 3.b.2: Build and run Leksah
 ###### For Mac OS
 ```shell
 stack install --stack-yaml stack.osx.yaml

--- a/Readme.md
+++ b/Readme.md
@@ -88,14 +88,14 @@ cabal install haskell-gi
 echo 'Shell is '"$SHELL"
 echo 'With PATH='"$SHELL"' -c '"echo $PATH"
 ```
-Make sure `~/.cabal/bin` is present in PATH of your shell (*Windows:* Make sure `%APPDATA%\cabal\bin` is present in PATH).
+Make sure `~/.cabal/bin` is present in PATH of your $SHELL (*Windows:* Make sure `%APPDATA%\cabal\bin` is present in PATH).
 
-To add cabal path to BASH:
+To add cabal path to $SHELL automatically:
 ```shell
-sed -i 's;^PATH=.*;PATH='"$SHELL"' -c '"echo $PATH"':'"$HOME"'/.cabal/bin;' ~/.bashrc
+sed -i 's;^PATH=.*;PATH='"$SHELL"' -c '"echo $PATH"':'"$HOME"'/.cabal/bin;' ~/.`basename "$SHELL"`'rc'
 ```
 
-If ZSH is your `$SHELL` - change file `~/.zshrc` instead.
+This line runs "$SHELL" gets "$PATH" there and expands it with `:"$HOME"'/.cabal/bin` in according config-file.
 
 ##### Step 3.a.2: Build and run Leksah
 ###### OS X using MacPorts

--- a/Readme.md
+++ b/Readme.md
@@ -86,7 +86,7 @@ cabal update
 cabal install alex happy
 cabal install haskell-gi
 echo 'Shell is '"$SHELL"
-echo 'With PATH='"$SHELL"' -c '"echo $PATH"
+echo 'With PATH='`"$SHELL" -c 'echo "$PATH"'`
 ```
 Make sure `~/.cabal/bin` is present in PATH of your $SHELL (*Windows:* Make sure `%APPDATA%\cabal\bin` is present in PATH).
 

--- a/Readme.md
+++ b/Readme.md
@@ -92,10 +92,21 @@ Make sure `~/.cabal/bin` is present in PATH of your $SHELL (*Windows:* Make sure
 
 To add cabal path to $SHELL automatically:
 ```shell
-sed -i 's;^PATH=.*;PATH='`"$SHELL" -c 'echo "$PATH"'`':'"$HOME"'/.cabal/bin;' ~/.`basename "$SHELL"`'rc'
-```
+# construct conf filename of shell
+conf_file=~'/.'`basename "$SHELL"`'rc'
 
-This line runs "$SHELL" gets "$PATH" there and expands it with `:"$HOME"'/.cabal/bin` in according config-file.
+# directory to add
+add_dir="$HOME"'/.cabal/bin'
+
+# run "$SHELL" get its "$PATH"
+old_PATH=`"$SHELL" -c 'echo "$PATH"'`
+
+# add directory to PATH
+new_PATH="$old_PATH"':'"$add_dir"
+
+# make change of value in config file
+sed -i 's;'"$old_PATH"';'"$new_PATH"';' "$conf_file"
+```
 
 ##### Step 3.a.2: Build and run Leksah
 ###### OS X using MacPorts

--- a/Readme.md
+++ b/Readme.md
@@ -92,7 +92,7 @@ Make sure `~/.cabal/bin` is present in PATH of your $SHELL (*Windows:* Make sure
 
 To add cabal path to $SHELL automatically:
 ```shell
-sed -i 's;^PATH=.*;PATH='"$SHELL"' -c '"echo $PATH"':'"$HOME"'/.cabal/bin;' ~/.`basename "$SHELL"`'rc'
+sed -i 's;^PATH=.*;PATH='`"$SHELL" -c 'echo "$PATH"'`':'"$HOME"'/.cabal/bin;' ~/.`basename "$SHELL"`'rc'
 ```
 
 This line runs "$SHELL" gets "$PATH" there and expands it with `:"$HOME"'/.cabal/bin` in according config-file.

--- a/leksah.sh
+++ b/leksah.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+VERSION='0.16.2.2'
+LEKSAH_SERVER_BUILD_DIR=`pwd`'/dist-newstyle/build/leksah-server-'"$VERSION"'/build'
+LEKSAH_BUILD_DIR='dist-newstyle/build/leksah-'"$VERSION"'/build'
+
 cabal new-build -j4 exe:leksah-server exe:leksah exe:leksahecho || exit
-PATH=`pwd`/dist-newstyle/build/leksah-server-0.16.2.0/build/leksah-server:`pwd`/dist-newstyle/build/leksah-server-0.16.2.0/build/leksahecho:$PATH leksah_datadir=`pwd` ./dist-newstyle/build/leksah-0.16.2.0/build/leksah/leksah $@
+PATH="$LEKSAH_SERVER_BUILD_DIR"'/leksah-server:'"$LEKSAH_SERVER_BUILD_DIR"'/leksahecho:'"$PATH" leksah_datadir=`pwd` ./"$LEKSAH_BUILD_DIR"/leksah/leksah $@
 

--- a/leksah.sh
+++ b/leksah.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-VERSION='0.16.2.2'
-LEKSAH_SERVER_BUILD_DIR=`pwd`'/dist-newstyle/build/leksah-server-'"$VERSION"'/build'
-LEKSAH_BUILD_DIR='dist-newstyle/build/leksah-'"$VERSION"'/build'
+LEKSAH_SERVER_VERSION='0.16.1.0'
+LEKSAH_VERSION='0.16.2.2'
+
+LEKSAH_SERVER_BUILD_DIR=`pwd`'/dist-newstyle/build/leksah-server-'"$LEKSAH_SERVER_VERSION"'/build'
+LEKSAH_BUILD_DIR='dist-newstyle/build/leksah-'"$LEKSAH_VERSION"'/build'
 
 cabal new-build -j4 exe:leksah-server exe:leksah exe:leksahecho || exit
-PATH="$LEKSAH_SERVER_BUILD_DIR"'/leksah-server:'"$LEKSAH_SERVER_BUILD_DIR"'/leksahecho:'"$PATH" leksah_datadir=`pwd` ./"$LEKSAH_BUILD_DIR"/leksah/leksah $@
-
+PATH="$LEKSAH_SERVER_BUILD_DIR"'/leksah-server:'"$LEKSAH_SERVER_BUILD_DIR"'/leksahecho:'"$PATH" leksah_datadir=`pwd` ./"$LEKSAH_BUILD_DIR"'/leksah/leksah' $@


### PR DESCRIPTION
* _Fix brackets in PATH oneliner_
I made an error, noticed it, fixed it.
"$SHELL"' -c '"echo $PATH" was returning '/bin/bash -c echo _PATH_' instead of value.

* _changing PATH oneliner to little script_
This is additional expansion. It  has more clear algorithm and more clear for understanding, it finds and changes value directly.
`^PATH=*` not matching line if it is `export PATH=` or what if it is `PATH="`.

Accepting or not last commit, I already spent time, so going to save this and expand, and commit to Stack auto-install, if I already spent time and started.

Thank you.
Shell scripts are being shell scripts.