### PR TITLE
Compiled leksah with lts-8.21

### DIFF
--- a/src/IDE/Command.hs
+++ b/src/IDE/Command.hs
@@ -598,8 +598,8 @@ makeMenu uiManager actions menuDescription = reifyIDE (\ideR -> do
 getMenuAndToolbars :: MonadIO m => UIManager -> m (AccelGroup, MenuBar, Toolbar)
 getMenuAndToolbars uiManager = do
     accGroup <- uIManagerGetAccelGroup uiManager
-    menu     <- uIManagerGetWidget uiManager "/ui/menubar" >>= liftIO . unsafeCastTo MenuBar
-    toolbar  <- uIManagerGetWidget uiManager "/ui/toolbar" >>= liftIO . unsafeCastTo Toolbar
+    menu     <- uIManagerGetWidget uiManager "/ui/menubar" >>= liftIO . unsafeCastTo MenuBar . fromMaybe (error "Failed to get menu widget! (Nothing)")
+    toolbar  <- uIManagerGetWidget uiManager "/ui/toolbar" >>= liftIO . unsafeCastTo Toolbar . fromMaybe (error "Failed to get menu widget! (Nothing)")
     toolbarSetStyle toolbar ToolbarStyleIcons
     toolbarSetIconSize toolbar IconSizeLargeToolbar
     widgetSetSizeRequest toolbar 700 (-1)

--- a/src/IDE/Pane/Modules.hs
+++ b/src/IDE/Pane/Modules.hs
@@ -89,6 +89,7 @@ import GI.Gtk.Objects.Paned (panedNew, Paned(..))
 import Data.GI.Gtk.ModelView.ForestStore
        (forestStoreInsertTree, forestStoreGetTree, forestStoreGetValue,
         ForestStore(..))
+import GI.Gtk.Objects.Button (Button (..))
 import GI.Gtk.Objects.RadioButton
        (radioButtonNewWithLabelFromWidget, radioButtonNewWithLabel,
         RadioButton(..))
@@ -1360,7 +1361,7 @@ addModuleDialog parent modString sourceRoots hasLib exesTests = do
     upper              <- dialogGetContentArea dia >>= liftIO . unsafeCastTo Box
     (widget,inj,ext,_) <- liftIO $ buildEditor (moduleFields sourceRoots hasLib exesTests)
                                         (AddModule modString (head sourceRoots) (Just False) Set.empty)
-    okButton <- dialogAddButton' dia (__"Add Module") ResponseTypeOk
+    okButton <- dialogAddButton' dia (__"Add Module") ResponseTypeOk >>= liftIO . unsafeCastTo Button
     dialogSetDefaultResponse' dia ResponseTypeOk
     dialogAddButton' dia (__"Cancel") ResponseTypeCancel
 

--- a/src/IDE/Preferences.hs
+++ b/src/IDE/Preferences.hs
@@ -86,7 +86,7 @@ import GI.Gtk.Enums
        (FileChooserAction(..), ShadowType(..), ResponseType(..),
         ButtonBoxStyle(..))
 import GI.Gtk.Objects.Button
-       (onButtonClicked, buttonNewWithLabel)
+       (onButtonClicked, buttonNewWithLabel, Button (..))
 import GI.Gtk.Objects.Label (labelSetMarkup, labelNew)
 import GI.Gtk.Objects.Widget
        (widgetModifyFont, widgetDestroy, widgetShowAll, widgetGrabDefault,
@@ -124,7 +124,7 @@ runPreferencesDialog = do
     actionArea <- dialogGetHeaderBar dialog >>= unsafeCastTo Container
     preview <- buttonNewWithLabel (__ "Preview")
     containerAdd actionArea preview
-    apply   <-  dialogAddButton' dialog "gtk-apply" ResponseTypeOk
+    apply   <-  dialogAddButton' dialog "gtk-apply" ResponseTypeOk >>= liftIO . unsafeCastTo Button
     dialogSetDefaultResponse' dialog ResponseTypeOk
 
     upper <-   dialogGetContentArea dialog >>= unsafeCastTo Box

--- a/src/IDE/Utils/GUIUtils.hs
+++ b/src/IDE/Utils/GUIUtils.hs
@@ -338,7 +338,10 @@ setDarkState b = do
 getMenuItem :: Text -> IDEM MenuItem
 getMenuItem path = (do
     uiManager' <- getUiManager
-    uIManagerGetWidget uiManager' path >>= (liftIO . unsafeCastTo MenuItem))
+    mMenuItem <- uIManagerGetWidget uiManager' path
+    case mMenuItem of
+      Nothing -> throwIDE ("State.hs>>getMenuItem: Can't find ui path " <> path)
+      Just item -> liftIO $ unsafeCastTo MenuItem item)
         `catchIDE` \(_::UnexpectedNullPointerReturn) ->
             throwIDE ("State.hs>>getMenuItem: Can't find ui path " <> path)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.12
+resolver: lts-8.21
 packages:
 - '.'
 - 'vendor/leksah-server'
@@ -18,7 +18,7 @@ extra-deps:
 - binary-shared-0.8.3
 - ghcjs-dom-0.8.0.0
 - ghcjs-dom-jsaddle-0.8.0.0
-- gi-gtk-hs-0.3.4.2
+- gi-gtk-hs-0.3.4.3
 - gi-gtksource-3.0.13
 - gi-javascriptcore-4.0.12
 - gi-soup-2.4.12
@@ -30,7 +30,7 @@ extra-deps:
 - gi-gdkpixbuf-2.0.12
 - gi-glib-2.0.12
 - gi-gobject-2.0.12
-- gi-gtk-3.0.14
+- gi-gtk-3.0.15
 - gi-cairo-1.0.12
 - gi-gio-2.0.12
 - gi-pango-1.0.13


### PR DESCRIPTION
I've just managed to compile leksah using stack with `lat-8.21`. There are couple things changed `gi-gtk-*`:

 * `uIManagerGetWidget` now returns `Maybe Widget`
 * `onButtonClicked` requires `Button` instead of `Widget`

Not sure if this PR is a good way to adapt to new changes, but maybe you find the information above useful.
I have not tested it with cabal.