### PR TITLE
Fix cabal package name in nix instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ cd leksah
 nix-env -f . -i
 ```
 
-When you run `leksah` it will expect to see `ghc` and `cabal` in the `PATH`.  You can install these with `nix-env -i ghc cabal` or you can run `leksah` inside a suitable `nix-shell`.  The [Reflex Platform](https://github.com/reflex-frp/reflex-platform#reflex-platform-) has a `./try-reflex` shell that includes `ghc`, `ghcjs` and `cabal`.
+When you run `leksah` it will expect to see `ghc` and `cabal` in the `PATH`.  You can install these with `nix-env -i ghc cabal-install` or you can run `leksah` inside a suitable `nix-shell`.  The [Reflex Platform](https://github.com/reflex-frp/reflex-platform#reflex-platform-) has a `./try-reflex` shell that includes `ghc`, `ghcjs` and `cabal`.
 
 If you want to make changes to Leksah run the `./leksah-nix.sh` script to start Leksah itself in a nix-shell with everything needed to work on Leksah.  Then open the Leksah `cabal.project` file.
 


### PR DESCRIPTION
I could be mistaken but I can't seem to get the instructions to work as is. It seems like there is no [cabal package on nix](https://nixos.org/nixos/packages.html#cabal) but there is a `cabal-install`. Could this have been an oversight from [the original commit](https://github.com/leksah/leksah/commit/d4a36a68d1cdfd8499a3ccdabd6facbc5d58b96d)?

P.S. I feel obliged to express my deepest appreciation for providing the nix instructions! Thank you so much! I have yet to get it working perfectly but it was a huge step forward in lowering the barrier to entry for me!