### PR TITLE
Revert "Readme md contribution for haskel home brew"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,12 +104,7 @@ echo 'PATH: '"$PATH"
 Make sure the `$HOME/ghc-8.4.3/bin` is present in PATH.
 
 ##### macOS with Homebrew
-With cask hombrew and cask already installed execute:
-```shell
-brew cask install leksah
-```
-Otherwise follow this instructions to install brew cask
-* [Mac Appstore Leksah](http://macappstore.org/leksah/)
+It might be possible to build Leksah using Homebrew now we have switched to WebKit 2.  If you can figure it out please send us the details or better yet a pull request to update this file.  Raise an issue if you try and it does not work.
 
 ##### FreeBSD
 ```shell


### PR DESCRIPTION
Reverts leksah/leksah#463

This is in the wrong place.  It is under the section heading `Step 1: Install C libraries`, but (as far as I can tell) it just installs one of the old Leksah binary DMG files.  These DMG files are currently significantly out of date.

I think we can generate the DMG files again with Nix (instead of macPorts), but it will require writing a nix script to use `install_name_tool` to make relocatable versions of the nix binaries.