### PR TITLE
Add instructions for setting up the IOHK binary cache

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,16 @@ This works even if you are not planning on using reflex in your project.
 
 Install [Nix](https://nixos.org/nix/).
 
+Leksah uses the cached builds provided by [IOHK](https://iohk.io). Setting these
+up will allow you to use their prebuilt GHC binaries and packages. This is
+*highly recommended*.
+
+If you're using [NixOS](https://nixos.org/) then follow the instructions located
+at: https://github.com/input-output-hk/plutus#iohk-binary-cache.
+
+Otherwise you can use the following instructions for adding the caches to your
+local Nix install: https://github.com/input-output-hk/cardano-sl/blob/master/docs/nix.md#binary-cache
+
 Then download, build and run Leksah with:
 
 ```


### PR DESCRIPTION
This might help nix users from having to build the universe. Without adding the caches I found myself building the patched(?) GHC from IOHK.

On NixOS I had to comment out the `executable leksah-wkwebview` in the cabal file. If that was left in then the nix would complain about `jsaddle-wkwebview` being missing and the build would fail. Unsure if that's just pebkac though.