### PR TITLE
Build with cabal 3.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,7 +90,7 @@ sudo dnf install gobject-introspection-devel webkitgtk4-devel gtksourceview3-dev
 
 ##### Ubuntu/Debian
 ```shell
-sudo apt-get install libgirepository1.0-dev libwebkit2gtk-4.0-dev libgtksourceview-3.0-dev
+sudo apt-get install libgirepository1.0-dev libwebkit2gtk-4.0-dev libgtksourceview-3.0-dev libtinfo-dev
 ```
 
 ##### Arch Linux

--- a/leksah.sh
+++ b/leksah.sh
@@ -19,24 +19,30 @@ if [[ "$GHCVER" == "" ]]; then
   GHCVER="$(ghc --numeric-version)"
 fi
 
-if [[ "$(cabal --numeric-version | cut -f 1 -d '.')" == "1" ]]; then
-  echo "Using Cabal 1"
-  LEKSAH_SERVER_BUILD_DIR="$DIR/dist-newstyle/build/leksah-server-$LEKSAH_SERVER_VERSION/build"
-  LEKSAH_BUILD_DIR="$DIR/dist-newstyle/build/leksah-$LEKSAH_VERSION/build"
-  export PATH="$LEKSAH_SERVER_BUILD_DIR/leksah-server:$LEKSAH_SERVER_BUILD_DIR/leksahecho:$PATH"
-  RUN_LEKSAH="$LEKSAH_BUILD_DIR/leksah/leksah"
-elif [[ "$(cabal --numeric-version | cut -f 1 -d '.')" = "2" ]]; then
-  echo "Using Cabal 2"
-  LEKSAH_SERVER_BUILD_DIR="$DIR/dist-newstyle/build/$ARCH-$OS/ghc-$GHCVER/leksah-server-$LEKSAH_SERVER_VERSION"
-  LEKSAH_BUILD_DIR="$DIR/dist-newstyle/build/$ARCH-$OS/ghc-$GHCVER/leksah-$LEKSAH_VERSION"
-  export PATH="$LEKSAH_SERVER_BUILD_DIR/c/leksah-server/build/leksah-server:$LEKSAH_SERVER_BUILD_DIR/c/leksah-server/build/leksahecho:$PATH"
-  export PATH="$LEKSAH_SERVER_BUILD_DIR/x/leksah-server/build/leksah-server:$LEKSAH_SERVER_BUILD_DIR/x/leksah-server/build/leksahecho:$PATH"
-  export PATH="$LEKSAH_BUILD_DIR/x/leksah/build/leksah:$LEKSAH_BUILD_DIR/c/leksah/build/leksah:$PATH"
-  RUN_LEKSAH="leksah"
-  echo $PATH
-else
-  echo "Unknown cabal version $(cabal --numeric-version)"
-fi
+case "$(cabal --numeric-version | cut -f 1 -d '.')" in
+    1)
+      echo "Using Cabal 1"
+      LEKSAH_SERVER_BUILD_DIR="$DIR/dist-newstyle/build/leksah-server-$LEKSAH_SERVER_VERSION/build"
+      LEKSAH_BUILD_DIR="$DIR/dist-newstyle/build/leksah-$LEKSAH_VERSION/build"
+      export PATH="$LEKSAH_SERVER_BUILD_DIR/leksah-server:$LEKSAH_SERVER_BUILD_DIR/leksahecho:$PATH"
+      RUN_LEKSAH="$LEKSAH_BUILD_DIR/leksah/leksah"
+      ;;
+
+  2|3)
+      echo "Using Cabal 2 or 3"
+      LEKSAH_SERVER_BUILD_DIR="$DIR/dist-newstyle/build/$ARCH-$OS/ghc-$GHCVER/leksah-server-$LEKSAH_SERVER_VERSION"
+      LEKSAH_BUILD_DIR="$DIR/dist-newstyle/build/$ARCH-$OS/ghc-$GHCVER/leksah-$LEKSAH_VERSION"
+      export PATH="$LEKSAH_SERVER_BUILD_DIR/c/leksah-server/build/leksah-server:$LEKSAH_SERVER_BUILD_DIR/c/leksah-server/build/leksahecho:$PATH"
+      export PATH="$LEKSAH_SERVER_BUILD_DIR/x/leksah-server/build/leksah-server:$LEKSAH_SERVER_BUILD_DIR/x/leksah-server/build/leksahecho:$PATH"
+      export PATH="$LEKSAH_BUILD_DIR/x/leksah/build/leksah:$LEKSAH_BUILD_DIR/c/leksah/build/leksah:$PATH"
+      RUN_LEKSAH="leksah"
+      echo $PATH
+      ;;
+
+  *)
+      echo "Unknown cabal version $(cabal --numeric-version)"
+      ;;
+esac
 
 export leksah_datadir="$DIR"
 export leksah_server_datadir="$DIR/vendor/leksah-server"
@@ -48,4 +54,3 @@ while [ $LEKSAH_EXIT_CODE -eq 2 ]; do
   $RUN_LEKSAH --develop-leksah $@
   LEKSAH_EXIT_CODE=$?
 done
-


### PR DESCRIPTION
Modify build script to support Cabal 3.0 (using same code as for Cabal 2.0).

Also, modify install instructions for Ubuntu, since I had to install an additional library package to compile.