### PR TITLE
Change "Version Control" alt key from _t to _c

### DIFF
--- a/data/git.menu
+++ b/data/git.menu
@@ -1,6 +1,6 @@
   <ui>
     <menubar>
-      <menu name="Version Con_trol" action="vcs">
+      <menu name="Version _Control" action="vcs">
         <menuitem name="_Commit" action="GitCommit" />
         <menuitem name="_View Log" action="GitViewLog" />
         <menuitem name="_Push" action="GitPush" />

--- a/data/leksah.menu
+++ b/data/leksah.menu
@@ -177,7 +177,7 @@
        <menuitem name="_Preferences" action="PrefsEdit" />
        <separator/>
     </menu>
-    <menu name="Version Con_trol" action="vcs">
+    <menu name="Version _Control" action="vcs">
     </menu>
     <menu name="_Help" action="Help">
        <menuitem name="_Homepage" action="HelpHomepage" />

--- a/data/svn.menu
+++ b/data/svn.menu
@@ -1,6 +1,6 @@
   <ui>
     <menubar>
-      <menu name="Version Con_trol" action="vcs">
+      <menu name="Version _Control" action="vcs">
         <menuitem name="_Commit" action="SvnCommit" />
         <menuitem name="_View Log" action="SvnViewLog" />
         <menuitem name="_Update" action="SvnUpdate" />

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1255,7 +1255,7 @@ msgid "Workspace >> workspaceSelect: invalid path"
 msgstr ""
 
 #: src/IDE/Command.hs:0
-msgid "Version Con_trol"
+msgid "Version _Control"
 msgstr ""
 
 #: src/IDE/Command.hs:0

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1266,7 +1266,7 @@ msgid "Workspace >> workspaceSelect: invalid path"
 msgstr "Workspace >> workspaceSelect: caminho invaálido"
 
 #: src/IDE/Command.hs:0
-msgid "Version Con_trol"
+msgid "Version _Control"
 msgstr "Con_trole de Versão"
 
 #: src/IDE/Command.hs:0

--- a/src-gtk/IDE/Utils/GUIUtils.hs
+++ b/src-gtk/IDE/Utils/GUIUtils.hs
@@ -432,7 +432,7 @@ getRecentFiles    = getMenuItem "ui/menubar/_File/Recent Files"
 
 
 getRecentWorkspaces = getMenuItem "ui/menubar/_File/Recent Workspaces"
-getVCS = getMenuItem "ui/menubar/Version Con_trol" --this could fail, try returning Menu if it does
+getVCS = getMenuItem "ui/menubar/Version _Control" --this could fail, try returning Menu if it does
 -- (toolbar)
 
 stockIdFromType :: DescrType -> Text

--- a/src/IDE/Command.hs
+++ b/src/IDE/Command.hs
@@ -201,7 +201,7 @@ printf = S.printf . T.unpack
 mkActions :: [ActionDescr IDERef]
 mkActions =
     [
-    AD "vcs" (__ "Version Con_trol") Nothing Nothing (return ()) [] False
+     AD "vcs" (__ "Version _Control") Nothing Nothing (return ()) [] False
     ,AD "FilePrint" (__ "_Print File") Nothing Nothing filePrint [] False
     ,AD "File" (__ "_File") Nothing Nothing (return ()) [] False
     ,AD "FileNew" (__ "_New") Nothing Nothing (return ()) [] False


### PR DESCRIPTION
"_t" conflicts with the Tools menu. Memorizing alt shortcuts is impossible when they are ambiguous.

Coincidentally, the pt_BR translation uses "_t" as well. I did not review the translation to see if either _t or _c was unique there, and left it as-is.