### PR TITLE
Bugs in candy files

### DIFF
--- a/data/candy-hasklig.lkshc
+++ b/data/candy-hasklig.lkshc
@@ -60,7 +60,8 @@
 "*"         0x22C5                  -- DOT OPERATOR
 "undefined" 0x22A5                  -- UP TACK
 "Integer"   0x2124                  -- DOUBLE-STRUCK CAPITAL Z
-"Ratio Integer" 0x2124              -- DOUBLE-STRUCK CAPITAL Q
+"Ratio Integer" 0x211A              -- DOUBLE-STRUCK CAPITAL Q
+
 
 -- Leksah specific?
 --hasklig "->"        0x2192                  --RIGHTWARDS ARROW          

--- a/data/candy-hasklig.lkshc
+++ b/data/candy-hasklig.lkshc
@@ -47,7 +47,7 @@
 "intersect" 0x2229                  -- INTERSECTION
 
 -- Data.Monoid.Unicode
-"mempty"    0x2205                  -- EMPTY SET
+-- "mempty"    0x2205                  -- EMPTY SET; used by "empty"
 "mappend"   0x2295                  -- CIRCLED PLUS
 
 -- Data.Ord.Unicode

--- a/data/candy.lkshc
+++ b/data/candy.lkshc
@@ -47,7 +47,7 @@
 "intersect" 0x2229                  -- INTERSECTION
 
 -- Data.Monoid.Unicode
-"mempty"    0x2205                  -- EMPTY SET
+--"mempty"    0x2205                  -- EMPTY SET; used by "empty"
 "mappend"   0x2295                  -- CIRCLED PLUS
 
 -- Data.Ord.Unicode

--- a/data/candy.lkshc
+++ b/data/candy.lkshc
@@ -60,7 +60,7 @@
 "*"         0x22C5                  -- DOT OPERATOR
 "undefined" 0x22A5                  -- UP TACK
 "Integer"   0x2124                  -- DOUBLE-STRUCK CAPITAL Z
-"Ratio Integer" 0x2124              -- DOUBLE-STRUCK CAPITAL Q
+"Ratio Integer" 0x211A              -- DOUBLE-STRUCK CAPITAL Q
 
 -- Leksah specific?
 "->"        0x2192                  --RIGHTWARDS ARROW


### PR DESCRIPTION
Fixed a couple of bugs in the candy file, namely the same "candy" symbol used for multiple plaintext expansions. Of course, that conversion mapping only works in one direction