### PR TITLE
Easy peasy message dialogs

### DIFF
--- a/src-gtk/IDE/Gtk/Workspaces.hs
+++ b/src-gtk/IDE/Gtk/Workspaces.hs
@@ -55,9 +55,6 @@ import qualified Data.Text as T
        (unpack, pack)
 import qualified Data.Text.IO as T (writeFile)
 
-import qualified Text.Printf as S (printf)
-import Text.Printf (PrintfType)
-
 import System.Directory
        (doesDirectoryExist, getDirectoryContents, getHomeDirectory,
         doesFileExist)
@@ -110,16 +107,13 @@ import IDE.Pane.SourceBuffer
        (belongsToWorkspace, IDEBuffer(..), maybeActiveBuf, fileOpenThis)
 import IDE.Pane.PackageEditor (packageNew', packageClone, choosePackageFile)
 import IDE.Utils.GUIUtils
-       (showDialog, showDialogOptions, chooseFile, chooseSaveFile, __)
+       (showDialog, showDialogOptions, chooseFile, chooseSaveFile, __, printf)
 import IDE.Utils.FileUtils (myCanonicalizePath)
 import IDE.Workspaces.Writer (WorkspaceFile(..))
 import qualified IDE.Workspaces.Writer as Writer
 import IDE.Workspaces
        (projectNewHere, projectOpenThis, workspaceTryQuiet, projectTryQuiet,
         projectAddPackage', constructAndOpenMainModules, makePackage', packageTryQuiet)
-
-printf :: PrintfType r => Text -> r
-printf = S.printf . T.unpack
 
 -- | Constructs a new workspace and makes it the current workspace
 workspaceNew :: IDEAction

--- a/src-gtk/IDE/Pane/Modules.hs
+++ b/src-gtk/IDE/Pane/Modules.hs
@@ -89,7 +89,7 @@ import Graphics.UI.Editor.Simple
        (textEditor, boolEditor, staticListEditor)
 import Graphics.UI.Editor.Composite (maybeEditor)
 import IDE.Utils.GUIUtils
-       (stockIdFromType, __, printf, treeViewContextMenu, treeViewToggleRow)
+       (stockIdFromType, __, printf, treeViewContextMenu, treeViewToggleRow, showConfirmDialog)
 import IDE.Metainfo.Provider
        (getSystemInfo, getWorkspaceInfo, getPackageInfo)
 import System.Log.Logger (debugM)
@@ -176,9 +176,6 @@ import GI.Gtk.Objects.MenuItem
        (toMenuItem, onMenuItemActivate, menuItemNewWithLabel)
 import GI.Gtk.Objects.SeparatorMenuItem (separatorMenuItemNew)
 import GI.Gtk.Objects.MenuShell (menuShellAppend)
-import GI.Gtk.Objects.MessageDialog
-       (setMessageDialogText, constructMessageDialogButtons, setMessageDialogMessageType,
-        MessageDialog(..))
 import GI.Gtk.Objects.Dialog
        (Dialog(..), dialogGetContentArea, constructDialogUseHeaderBar)
 import GI.Gtk.Objects.Window
@@ -1271,18 +1268,8 @@ respDelModDialog :: IDEM Bool
 respDelModDialog = do
     liftIO $ debugM "leksah" "respDelModDialog"
     window <- getMainWindow
-    dia <- new' MessageDialog [
-                    constructDialogUseHeaderBar 0,
-                    constructMessageDialogButtons ButtonsTypeCancel]
-    setMessageDialogMessageType dia MessageTypeQuestion
-    setMessageDialogText dia $ __ "Are you sure?"
-    windowSetTransientFor dia (Just window)
-    _ <- dialogAddButton' dia (__ "_Delete Module") (AnotherResponseType 1)
-    dialogSetDefaultResponse' dia ResponseTypeCancel
-    setWindowWindowPosition dia WindowPositionCenterOnParent
-    resp <- dialogRun' dia
-    widgetDestroy dia
-    return $ resp == AnotherResponseType 1
+    isConfirmed <- showConfirmDialog (Just window) False (__ "_Delete Module") $ __ "Are you sure?"
+    return isConfirmed
 
 addModule' :: TreeView -> ForestStore ModuleRecord -> PackageAction
 addModule' treeView store = do

--- a/src-gtk/IDE/Pane/Modules.hs
+++ b/src-gtk/IDE/Pane/Modules.hs
@@ -89,7 +89,7 @@ import Graphics.UI.Editor.Simple
        (textEditor, boolEditor, staticListEditor)
 import Graphics.UI.Editor.Composite (maybeEditor)
 import IDE.Utils.GUIUtils
-       (stockIdFromType, __, treeViewContextMenu, treeViewToggleRow)
+       (stockIdFromType, __, printf, treeViewContextMenu, treeViewToggleRow)
 import IDE.Metainfo.Provider
        (getSystemInfo, getWorkspaceInfo, getPackageInfo)
 import System.Log.Logger (debugM)
@@ -100,8 +100,6 @@ import Control.Monad (when, void)
 import Control.Monad.Trans.Reader (ask)
 import Data.Text (Text, toCaseFold)
 import qualified Data.Text as T (unpack, isInfixOf, toLower, pack)
-import qualified Text.Printf as S (printf)
-import Text.Printf (PrintfType)
 import qualified Data.Text.IO as T (writeFile)
 import GI.Gtk.Objects.Paned
        (panedAdd2, panedAdd1, panedSetPosition, panedGetPosition,
@@ -194,9 +192,6 @@ import Data.Aeson (FromJSON(..), ToJSON(..))
 import GHC.Generics (Generic)
 import Distribution.Types.UnqualComponentName
        (unUnqualComponentName)
-
-printf :: PrintfType r => Text -> r
-printf = S.printf . T.unpack
 
 -- | A modules pane description
 --

--- a/src-gtk/IDE/Pane/PackageEditor.hs
+++ b/src-gtk/IDE/Pane/PackageEditor.hs
@@ -96,9 +96,6 @@ import System.Directory
         createDirectory, removeDirectoryRecursive, doesDirectoryExist,
         createDirectoryIfMissing)
 
-import qualified Text.Printf as S (printf)
-import Text.Printf (PrintfType)
-
 import Data.GI.Base (unsafeCastTo, new')
 import GI.Gtk.Enums
        (Align(..), ShadowType(..), WindowPosition(..), ButtonsType(..),
@@ -159,15 +156,13 @@ import IDE.Utils.ExternalTool (runExternalTool')
 import IDE.Utils.FileUtils
        (isEmptyDirectory, cabalFileName, allModules)
 import IDE.Utils.GUIUtils
+        (__, printf, chooseDir, chooseFile, showErrorDialog)
 import IDE.Utils.Tool (ToolOutput(..))
 
 #if !MIN_VERSION_Cabal(2,4,0)
 allBuildDepends :: PackageDescription -> [Dependency]
 allBuildDepends = buildDepends
 #endif
-
-printf :: PrintfType r => Text -> r
-printf = S.printf . T.unpack
 
 -- | Get the last item
 sinkLast :: ConduitT a o IDEM (Maybe a)

--- a/src-gtk/IDE/Pane/SourceBuffer.hs
+++ b/src-gtk/IDE/Pane/SourceBuffer.hs
@@ -179,7 +179,7 @@ import qualified GI.Gtk.Objects.Notebook as Gtk (Notebook(..))
 import GI.Gtk.Objects.ScrolledWindow
        (setScrolledWindowShadowType, scrolledWindowSetPolicy)
 import GI.Gtk.Objects.Widget
-       (widgetHide, widgetShow, widgetDestroy)
+       (widgetShow, widgetDestroy)
 import GI.Gtk.Objects.Window
        (setWindowTitle, setWindowWindowPosition, windowSetTransientFor)
 import qualified GI.Gtk.Objects.Window as Gtk (Window(..))
@@ -1071,7 +1071,7 @@ fileSaveBuffer query nb _ ebuf ideBuf@IDEBuffer{sourceView = sv} _i = liftIDE $ 
                             dialogSetDefaultResponse' md ResponseTypeCancel
                             setWindowWindowPosition md WindowPositionCenterOnParent
                             resp <- toEnum . fromIntegral <$> dialogRun md
-                            widgetHide md
+                            widgetDestroy md
                             return resp
                     else return ResponseTypeYes
                 case resp of

--- a/src-gtk/IDE/Pane/SourceBuffer.hs
+++ b/src-gtk/IDE/Pane/SourceBuffer.hs
@@ -1215,12 +1215,10 @@ fileClose' _ ebuf currentBuffer = do
                     ResponseTypeCancel -> return False
                     _                  -> return False
             else return True
-    if not shouldContinue
-        then return False
-        else do
-            _ <- closeThisPane currentBuffer
-            F.forM_ (fileName currentBuffer) addRecentlyUsedFile
-            return True
+    when shouldContinue $ do
+        _ <- closeThisPane currentBuffer
+        F.forM_ (fileName currentBuffer) addRecentlyUsedFile
+    return shouldContinue
 
 fileCloseAll :: (IDEBuffer -> IDEM Bool)  -> IDEM Bool
 fileCloseAll filterFunc = do

--- a/src-gtk/IDE/Pane/SourceBuffer.hs
+++ b/src-gtk/IDE/Pane/SourceBuffer.hs
@@ -1211,9 +1211,9 @@ fileClose' _ ebuf currentBuffer = do
                     ResponseTypeYes -> do
                         _ <- reflectIDE (fileSave False) ideR
                         return False
-                    ResponseTypeCancel -> return True
                     ResponseTypeNo     -> return False
-                    _                  -> return False
+                    ResponseTypeCancel -> return True
+                    _                  -> return True
             else return False
     if cancelled
         then return False
@@ -1319,8 +1319,8 @@ filePrint' _nb _ ebuf currentBuffer _ = do
         widgetDestroy md
         case resp of
             ResponseTypeYes     ->   return True
-            ResponseTypeCancel  ->   return False
             ResponseTypeNo      ->   return False
+            ResponseTypeCancel  ->   return False
             _                   ->   return False
     when yesPrint $ do
         --real code
@@ -1347,9 +1347,9 @@ filePrint' _nb _ ebuf currentBuffer _ = do
                         ResponseTypeYes ->   do
                             _ <- reflectIDE (fileSave False) ideR
                             return False
-                        ResponseTypeCancel  ->   return True
                         ResponseTypeNo      ->   return False
-                        _               ->   return False
+                        ResponseTypeCancel  ->   return True
+                        _               ->   return True
                 else
                     return False
         unless cancelled $

--- a/src-gtk/IDE/Pane/Trace.hs
+++ b/src-gtk/IDE/Pane/Trace.hs
@@ -47,11 +47,9 @@ import qualified Data.Conduit.List as CL (consume)
 import Control.Applicative (optional, (<$>), (<|>), many)
 import Control.Monad.Trans.Class (MonadTrans(..))
 import Control.Monad.IO.Class (MonadIO(..))
-import IDE.Utils.GUIUtils (treeViewContextMenu, __)
+import IDE.Utils.GUIUtils (treeViewContextMenu, __, printf)
 import Data.Text (Text)
 import qualified Data.Text as T (pack, unpack)
-import qualified Text.Printf as S (printf)
-import Text.Printf (PrintfType)
 import GI.Gtk.Objects.ScrolledWindow
        (scrolledWindowSetPolicy, scrolledWindowSetShadowType,
         scrolledWindowNew, ScrolledWindow(..))
@@ -96,9 +94,6 @@ import qualified Data.Attoparsec.Text as AP
        (decimal, string, skipSpace)
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
-
-printf :: PrintfType r => Text -> r
-printf = S.printf . T.unpack
 
 -- | A debugger pane description
 --

--- a/src-gtk/IDE/Utils/GUIUtils.hs
+++ b/src-gtk/IDE/Utils/GUIUtils.hs
@@ -19,6 +19,8 @@ module IDE.Utils.GUIUtils (
 ,   chooseSaveFile
 ,   openBrowser
 ,   showDialog
+,   showYesNoDialog
+,   showConfirmDialog
 ,   showErrorDialog
 ,   showDialogOptions
 ,   showDialogAndGetResponse
@@ -251,6 +253,37 @@ showDialog parent msg msgType = do
     widgetDestroy dialog
     return ()
 
+
+-- | Show a Yes/No dialog
+showYesNoDialog :: MonadIO m
+                => Maybe Window -- ^ Parent of transient
+                -> Bool         -- ^ Should Yes be selected by default?
+                -> Text         -- ^ Message
+                -> m Bool       -- ^ Was "Yes" chosen as user response?
+showYesNoDialog parent defaultYes message =
+    isYes <$> showDialogAndGetResponse parent message MessageTypeQuestion defaultResponse
+            [ constructDialogUseHeaderBar 0, constructMessageDialogButtons ButtonsTypeYesNo ]
+            []
+  where
+    defaultResponse = if defaultYes then ResponseTypeYes else ResponseTypeNo
+    isYes = (== ResponseTypeYes)
+
+
+-- | Show a confirmation dialog with a cancel button and a custom action
+-- button
+showConfirmDialog :: MonadIO m
+                   => Maybe Window  -- ^ Parent of transient
+                   -> Bool          -- ^ Should the custom action be selected by default?
+                   -> Text          -- ^ Label for custom action button
+                   -> Text          -- ^ Message
+                   -> m Bool        -- ^ Was the custom action chosen as user response?
+showConfirmDialog parent defaultConfirm action message =
+    isConfirm <$> showDialogAndGetResponse parent message MessageTypeQuestion defaultResponse
+            [ constructDialogUseHeaderBar 0 , constructMessageDialogButtons ButtonsTypeCancel ]
+            [ (action, AnotherResponseType 1) ]
+  where
+    defaultResponse = if defaultConfirm then AnotherResponseType 1 else ResponseTypeCancel
+    isConfirm = (== AnotherResponseType 1)
 
 -- | Show an error dialog with an Ok button
 showErrorDialog :: MonadIO m => Maybe Window -> Text -> m ()

--- a/src-gtk/IDE/Utils/GUIUtils.hs
+++ b/src-gtk/IDE/Utils/GUIUtils.hs
@@ -56,6 +56,7 @@ module IDE.Utils.GUIUtils (
 ,   treeViewContextMenu'
 
 ,   __
+,   printf
 
 ,   fontDescription
 ) where
@@ -76,6 +77,8 @@ import Data.Text (Text)
 import qualified Data.Text as T (unpack, pack)
 import Data.List (intercalate)
 import Data.Foldable (forM_)
+import qualified Text.Printf as S (printf)
+import Text.Printf (PrintfType)
 import GI.Gtk.Objects.Window
        (setWindowWindowPosition, windowSetTransientFor, setWindowTitle,
         Window(..))
@@ -137,6 +140,9 @@ import GI.Gdk.Constants (pattern BUTTON_SECONDARY)
 import GI.Gtk
        (menuPopupAtPointer, gestureGetLastEvent, onGestureBegin,
         gestureSingleSetButton, gestureMultiPressNew)
+
+printf :: PrintfType r => Text -> r
+printf = S.printf . T.unpack
 
 chooseDir :: Window -> Text -> Maybe FilePath -> IO (Maybe FilePath)
 chooseDir window prompt mbFolder = do

--- a/src-gtk/IDE/Utils/GUIUtils.hs
+++ b/src-gtk/IDE/Utils/GUIUtils.hs
@@ -277,7 +277,7 @@ showDialogOptions parent msg msgType buttons mbIndex = do
     dialogSetDefaultResponse' dialog (AnotherResponseType $ fromMaybe 0 mbIndex)
     setWindowWindowPosition dialog WindowPositionCenterOnParent
     res <- dialogRun' dialog
-    widgetHide dialog
+    widgetDestroy dialog
     case res of
         AnotherResponseType n | n >= 0 && n < length buttons -> map snd buttons !! n
         _ -> return ()

--- a/src/IDE/Command.hs
+++ b/src/IDE/Command.hs
@@ -124,8 +124,6 @@ import Data.Time.Calendar (toGregorian)
 import Data.Text (Text)
 import qualified Data.Text.IO as T (readFile)
 import Data.Monoid (Monoid(..))
-import qualified Text.Printf as S (printf)
-import Text.Printf (PrintfType)
 import GI.Gtk.Enums
        (IconSize(..), ToolbarStyle(..), PositionType(..), Orientation(..))
 import GI.Gtk.Objects.Menu (Menu(..), menuNew)
@@ -191,9 +189,6 @@ import Data.Attoparsec.Text (parseOnly)
 import IDE.HaRe
        (deleteDef, rmOneParameter, addOneParameter, rename, liftOneLevel,
         liftToTopLevel, duplicateDef, ifToCase, demote)
-
-printf :: PrintfType r => Text -> r
-printf = S.printf . T.unpack
 
 --
 -- | The Actions known to the system (they can be activated by keystrokes or menus)


### PR DESCRIPTION
Refactor most uses of MessageDialog so that they share common code. Not only does this get rid of a couple of memory leaks, it also ensures consistency between most dialogs in the app, and makes the source code much easier to read