### PR TITLE
leksah.org → leksah.github.io in  Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,11 +2,11 @@
 
 [![Build Status](https://secure.travis-ci.org/leksah/leksah.png)](http://travis-ci.org/leksah/leksah)
 
-[Leksah](http://leksah.org/) aims to integrate various Haskell development
+[Leksah](http://leksah.github.io/) aims to integrate various Haskell development
 tools to provide a practical and pleasant development environment.
 The user interface is a mix of GTK+ and WebKit based components.
 
-Documentation can be found on [leksah.org](http://leksah.org/).
+Documentation can be found on [leksah.github.io/](http://leksah.github.io/).
 
 ## Leksah's Nix Support
 


### PR DESCRIPTION
the old link seems to be dead, tried in two browsers x2 devices.

replaced with something that works at least.